### PR TITLE
Check output section in Output_section::set_final_data_size function

### DIFF
--- a/binutils-2.27/gold/output.cc
+++ b/binutils-2.27/gold/output.cc
@@ -3226,17 +3226,19 @@ namespace gold
             // CCR variables
             const char* insecname;
             off_t prev_raw_off = 0;
-            for (Input_section_list::iterator p = this->input_sections_.begin();
-                   p != this->input_sections_.end();
-                   ++p)
-            {
-                    if(p->is_input_section() && yarp_has_reorder){
+	    if (is_prefix_of(".text", this->name()){
+		    for (Input_section_list::iterator p = this->input_sections_.begin();
+			   p != this->input_sections_.end();
+			   ++p)
+		    {
+			    if(p->is_input_section() && yarp_has_reorder){
 #ifdef CCR_MSG_DETAILS
-                        gold_info("[lala]resetting object_id_map for %s", p->relobj()->name().c_str());
+				gold_info("[lala]resetting object_id_map for %s", p->relobj()->name().c_str());
 #endif
-                        p->relobj()->reset_yarp_object_id_map();
-                    }
-            }
+				p->relobj()->reset_yarp_object_id_map();
+			    }
+		    }
+	    }
             for (Input_section_list::iterator p = this->input_sections_.begin();
                  p != this->input_sections_.end();
                  ++p)


### PR DESCRIPTION
Hi, in `output.cc:Output_section::set_final_data_size` function, I add checking before `reset_yarp_object_id_map()`. Because sometimes this occurs when the output section is `.init_array`.